### PR TITLE
Show room player skeletons while waiting

### DIFF
--- a/apps/game/components/coinche/interface/join.vue
+++ b/apps/game/components/coinche/interface/join.vue
@@ -4,42 +4,55 @@
             <CardHeader>
                 <CardTitle>Joueurs</CardTitle>
                 <CardDescription>
-                    {{ storePlayers.players.length }} joueurs présents
+                    <Skeleton v-if="storePlayers.isLoadingPlayerList" class="h-4 w-32" />
+                    <span v-else>{{ storePlayers.players.length }} joueurs présents</span>
                 </CardDescription>
             </CardHeader>
             <CardContent>
                 <div class="grid grid-cols-3 gap-2">
                     <div />
                     <div>
-                        {{
-                            storePlayers.players.length > 0
-                                ? storePlayers.players[0].id
-                                : 'en attente'
-                        }}
+                        <Skeleton v-if="storePlayers.isLoadingPlayerList" class="h-6 w-20" />
+                        <span v-else>
+                            {{
+                                storePlayers.players.length > 0
+                                    ? storePlayers.players[0].id
+                                    : 'en attente'
+                            }}
+                        </span>
                     </div>
                     <div />
                     <div>
-                        {{
-                            storePlayers.players.length > 3
-                                ? storePlayers.players[3].id
-                                : 'en attente'
-                        }}
+                        <Skeleton v-if="storePlayers.isLoadingPlayerList" class="h-6 w-20" />
+                        <span v-else>
+                            {{
+                                storePlayers.players.length > 3
+                                    ? storePlayers.players[3].id
+                                    : 'en attente'
+                            }}
+                        </span>
                     </div>
                     <div />
                     <div>
-                        {{
-                            storePlayers.players.length > 1
-                                ? storePlayers.players[1].id
-                                : 'en attente'
-                        }}
+                        <Skeleton v-if="storePlayers.isLoadingPlayerList" class="h-6 w-20" />
+                        <span v-else>
+                            {{
+                                storePlayers.players.length > 1
+                                    ? storePlayers.players[1].id
+                                    : 'en attente'
+                            }}
+                        </span>
                     </div>
                     <div />
                     <div>
-                        {{
-                            storePlayers.players.length > 2
-                                ? storePlayers.players[2].id
-                                : 'en attente'
-                        }}
+                        <Skeleton v-if="storePlayers.isLoadingPlayerList" class="h-6 w-20" />
+                        <span v-else>
+                            {{
+                                storePlayers.players.length > 2
+                                    ? storePlayers.players[2].id
+                                    : 'en attente'
+                            }}
+                        </span>
                     </div>
                     <div />
                 </div>
@@ -49,5 +62,7 @@
 </template>
 
 <script setup lang="ts">
+    import Skeleton from '@/components/ui/skeleton/Skeleton.vue';
+    
     const storePlayers = usePlayersStore();
 </script>

--- a/apps/game/pages/partie.vue
+++ b/apps/game/pages/partie.vue
@@ -53,6 +53,9 @@ storeAbout.setGameId(gameId);
 let cleanupListener: (() => void) | null = null;
 
 onMounted(async () => {
+  // Reset loading state for player list
+  storePlayers.resetLoadingState();
+  
   // Connect to WebSocket and set up listener
   getWS();
   

--- a/apps/game/stores/players.ts
+++ b/apps/game/stores/players.ts
@@ -2,6 +2,7 @@ import type { Ibidding, ICard, IPlayer, PlayerPosition } from '@coinche/shared';
 
 export const usePlayersStore = defineStore('players', () => {
     const players = ref<IPlayer[]>([]);
+    const isLoadingPlayerList = ref<boolean>(true);
 
     function removeCard(card: ICard, playerId: string) {
         const player = players.value.find((player) => player.id === playerId);
@@ -23,6 +24,11 @@ export const usePlayersStore = defineStore('players', () => {
 
     function setPlayers(newPlayers: IPlayer[]) {
         players.value = newPlayers;
+        isLoadingPlayerList.value = false;
+    }
+
+    function resetLoadingState() {
+        isLoadingPlayerList.value = true;
     }
 
     function setLastbidding(bidding: Ibidding, playerId: string) {
@@ -48,6 +54,7 @@ export const usePlayersStore = defineStore('players', () => {
 
     return {
         players,
+        isLoadingPlayerList,
         team1,
         team2,
         removeCard,
@@ -55,5 +62,6 @@ export const usePlayersStore = defineStore('players', () => {
         addPlayer,
         setPlayers,
         setLastbidding,
+        resetLoadingState,
     };
 });


### PR DESCRIPTION
Add skeleton loading states for room players to improve UX before the player list is loaded.

This PR introduces a `isLoadingPlayerList` state in the players store, which is `true` by default and reset when entering a new room. The `CoincheInterfaceJoin` component now conditionally renders skeleton placeholders while `isLoadingPlayerList` is `true`, providing a visual indication of loading instead of immediately displaying "en attente" text. Once the `player_list` event is received, `isLoadingPlayerList` is set to `false`, and the actual player data or "en attente" text is displayed.

---

[Open in Web](https://cursor.com/agents?id=bc-07973285-be53-4408-96a6-c0c0df3dcb12) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-07973285-be53-4408-96a6-c0c0df3dcb12) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)