### PR TITLE
Add footer links except on game page

### DIFF
--- a/apps/game/app.vue
+++ b/apps/game/app.vue
@@ -38,7 +38,7 @@
     </header>
     <Separator />
     <NuxtPage />
-    <footer />
+    <OthersFooter v-if="!isGamePage" />
 
     <OthersDevEnv v-if="isDevEnv(config)" />
   </div>
@@ -54,8 +54,12 @@ import { Toaster } from "@/components/ui/sonner";
 import { isDevEnv } from "@/shared/utils/miscs";
 
 const config = useRuntimeConfig();
+const route = useRoute();
 
-const {loggedIn} = useAuth()
+const {loggedIn} = useAuth();
+
+// Check if current page is the game page
+const isGamePage = computed(() => route.path === '/partie');
 
 useSeoMeta({
   title: "Coinche.n7",

--- a/apps/game/components/others/footer.vue
+++ b/apps/game/components/others/footer.vue
@@ -1,0 +1,39 @@
+<template>
+  <footer class="mt-auto py-4 px-6 border-t border-gray-200 dark:border-gray-700 bg-secondary">
+    <div class="max-w-6xl mx-auto flex flex-col sm:flex-row items-center justify-between gap-4">
+      <div class="text-sm text-gray-600 dark:text-gray-400">
+        © 2024 Coinche.n7
+      </div>
+      
+      <div class="flex items-center gap-6">
+        <a 
+          href="https://github.com/newtondotcom/coinche" 
+          target="_blank" 
+          rel="noopener noreferrer"
+          class="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400 hover:text-primary transition-colors"
+        >
+          <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd" />
+          </svg>
+          GitHub
+        </a>
+        
+        <a 
+          href="https://github.com/sponsors/newtondotcom" 
+          target="_blank" 
+          rel="noopener noreferrer"
+          class="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400 hover:text-primary transition-colors"
+        >
+          <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>
+          </svg>
+          Sponsor
+        </a>
+      </div>
+    </div>
+  </footer>
+</template>
+
+<script setup lang="ts">
+// Footer component for all pages except the game page
+</script>


### PR DESCRIPTION
Add a footer with GitHub and sponsor links to all pages except the game page.

---

[Open in Web](https://cursor.com/agents?id=bc-f38a2b25-a789-44f1-9dd7-a44fed95aaad) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-f38a2b25-a789-44f1-9dd7-a44fed95aaad) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)