### PR TITLE
Bot player logic

### DIFF
--- a/packages/api/src/lib/actions/can.ts
+++ b/packages/api/src/lib/actions/can.ts
@@ -1,13 +1,16 @@
 import logger from "../logger";
+import { maybeScheduleBotTurn } from "../botScheduler";
 import { setPlayerIdToBid, setPlayerIdToPlay } from "./setIds";
 
 export async function emitCanPlay(playerId: string, gameId: string) {
   // Update the current player
   setPlayerIdToPlay(playerId, gameId);
   logger.info(`${playerId} can play`);
+  maybeScheduleBotTurn(gameId);
 }
 
 export async function emitCanBid(playerId: string, gameId: string) {
   setPlayerIdToBid(playerId, gameId);
   logger.info(`${playerId} can bidding`);
+  maybeScheduleBotTurn(gameId);
 }

--- a/packages/api/src/lib/actions/endGame.ts
+++ b/packages/api/src/lib/actions/endGame.ts
@@ -7,6 +7,7 @@ import { eq, or } from "drizzle-orm";
 
 import { db } from "@coinche-reborn/db";
 import controller from "../game";
+import { isBotId } from "../bot";
 import { addPointsTo } from "../utils";
 
 /**
@@ -59,6 +60,11 @@ export async function distributeRankingPoints(
   team1Score: number,
   team2Score: number,
 ) {
+  if (players.some((player) => isBotId(player.id))) {
+    logger.info(`[end_game] Skipping ranking updates for bot game ${gameId}`);
+    return;
+  }
+
   const playersIds = players.map((player) => player.id);
 
   // store in db the finished game

--- a/packages/api/src/lib/bot.ts
+++ b/packages/api/src/lib/bot.ts
@@ -1,0 +1,69 @@
+import type { IGameState, IPlayer, PlayerId, PlayerPosition } from "@coinche-reborn/api";
+
+const BOT_ID_PREFIX = "bot:";
+
+export function isBotId(playerId: PlayerId): boolean {
+  return playerId.startsWith(BOT_ID_PREFIX);
+}
+
+export function getBotId(gameId: string, position: PlayerPosition): PlayerId {
+  return `${BOT_ID_PREFIX}${gameId}:${position}`;
+}
+
+export function createBotPlayer(gameId: string, position: PlayerPosition): IPlayer {
+  return {
+    id: getBotId(gameId, position),
+    position,
+    hands: [],
+    classement: 0,
+  };
+}
+
+export function replacePlayerIdInState(
+  state: IGameState,
+  previousId: PlayerId,
+  nextId: PlayerId,
+) {
+  if (previousId === nextId) {
+    return;
+  }
+
+  const player = state.players.find((p) => p.id === previousId);
+  if (player) {
+    player.id = nextId;
+  }
+
+  state.team1 = state.team1.map((id) => (id === previousId ? nextId : id));
+  state.team2 = state.team2.map((id) => (id === previousId ? nextId : id));
+
+  if (state.phases.timeToBid === previousId) {
+    state.phases.timeToBid = nextId;
+  }
+  if (state.phases.timeToPlay === previousId) {
+    state.phases.timeToPlay = nextId;
+  }
+  if (state.phases.timeDistrib === previousId) {
+    state.phases.timeDistrib = nextId;
+  }
+
+  state.currentRound.biddings.forEach((bid) => {
+    if (bid.playerId === previousId) {
+      bid.playerId = nextId;
+    }
+  });
+
+  if (state.currentRound.biddingElected.playerId === previousId) {
+    state.currentRound.biddingElected.playerId = nextId;
+  }
+
+  state.currentRound.tricks.forEach((trick) => {
+    if (trick.playerStartingId === previousId) {
+      trick.playerStartingId = nextId;
+    }
+    trick.plays.forEach((play) => {
+      if (play.playerId === previousId) {
+        play.playerId = nextId;
+      }
+    });
+  });
+}

--- a/packages/api/src/lib/botScheduler.ts
+++ b/packages/api/src/lib/botScheduler.ts
@@ -1,0 +1,164 @@
+import type { ICard, Ibidding, ICardSuite, IPlayer } from "@coinche-reborn/api";
+import {
+  cardSuites,
+  cardValues,
+  formatbidding,
+  formatCarteToPlay,
+  genIdCuid,
+} from "@coinche-reborn/api";
+import controller from "./game";
+import logger from "./logger";
+import translateBidding from "./listener/bidding";
+import translatePlay from "./listener/play";
+import { isBotId } from "./bot";
+
+const BOT_ACTION_DELAY_MS = 300;
+const pendingActions = new Set<string>();
+
+export function maybeScheduleBotTurn(gameId: string) {
+  const state = controller.getInstance(gameId).state;
+  const bidderId = state.phases.timeToBid;
+  if (bidderId && isBotId(bidderId)) {
+    scheduleBotBid(gameId, bidderId);
+  }
+
+  const playerId = state.phases.timeToPlay;
+  if (playerId && isBotId(playerId)) {
+    scheduleBotPlay(gameId, playerId);
+  }
+}
+
+function scheduleBotBid(gameId: string, playerId: string) {
+  const key = `${gameId}:bid:${playerId}`;
+  if (pendingActions.has(key)) {
+    return;
+  }
+  pendingActions.add(key);
+  setTimeout(async () => {
+    pendingActions.delete(key);
+    await runBotBid(gameId, playerId);
+  }, BOT_ACTION_DELAY_MS);
+}
+
+function scheduleBotPlay(gameId: string, playerId: string) {
+  const key = `${gameId}:play:${playerId}`;
+  if (pendingActions.has(key)) {
+    return;
+  }
+  pendingActions.add(key);
+  setTimeout(async () => {
+    pendingActions.delete(key);
+    await runBotPlay(gameId, playerId);
+  }, BOT_ACTION_DELAY_MS);
+}
+
+async function runBotBid(gameId: string, playerId: string) {
+  const state = controller.getInstance(gameId).state;
+  if (state.status !== "playing") {
+    return;
+  }
+  if (state.phases.timeToBid !== playerId) {
+    return;
+  }
+
+  const player = state.players.find((p) => p.id === playerId);
+  if (!player) {
+    logger.warn(`[bot] Player ${playerId} not found in game ${gameId}`);
+    return;
+  }
+
+  const bid = selectBotBid(player, state.currentRound.biddingElected.bidding);
+  const event = {
+    id: await genIdCuid(),
+    type: "bidding",
+    playerId,
+    gameId,
+    value: formatbidding(bid),
+    timestamp: new Date().toISOString(),
+  };
+
+  logger.info(`[bot] Bid ${bid.bidding} ${bid.suite} for ${playerId} in game ${gameId}`);
+  await translateBidding(event);
+}
+
+async function runBotPlay(gameId: string, playerId: string) {
+  const state = controller.getInstance(gameId).state;
+  if (state.status !== "playing") {
+    return;
+  }
+  if (state.phases.timeToPlay !== playerId) {
+    return;
+  }
+
+  const player = state.players.find((p) => p.id === playerId);
+  const currentTrick = state.currentRound.tricks[state.currentRound.tricks.length - 1];
+  if (!player || !currentTrick) {
+    logger.warn(`[bot] Cannot play: missing player or trick in game ${gameId}`);
+    return;
+  }
+
+  const card = selectBotCard(player.hands);
+  if (!card) {
+    logger.warn(`[bot] No card to play for ${playerId} in game ${gameId}`);
+    return;
+  }
+
+  const event = {
+    id: await genIdCuid(),
+    type: "play",
+    playerId,
+    gameId,
+    value: formatCarteToPlay(card, currentTrick.number, currentTrick.plays.length),
+    timestamp: new Date().toISOString(),
+  };
+
+  logger.info(`[bot] Played ${card.suite}-${card.value} for ${playerId} in game ${gameId}`);
+  await translatePlay(event);
+}
+
+function selectBotBid(player: IPlayer, currentBid: number): Ibidding {
+  if (currentBid && currentBid !== 0) {
+    return { bidding: 0, suite: "NA", playerId: player.id };
+  }
+
+  const suit = pickPreferredSuit(player.hands);
+  return { bidding: 80, suite: suit, playerId: player.id };
+}
+
+function pickPreferredSuit(hand: ICard[]): ICardSuite {
+  const counts = new Map<ICardSuite, number>();
+  cardSuites.forEach((suite) => counts.set(suite, 0));
+  hand.forEach((card) => {
+    if (counts.has(card.suite)) {
+      counts.set(card.suite, (counts.get(card.suite) ?? 0) + 1);
+    }
+  });
+
+  let bestSuit: ICardSuite = cardSuites[0] ?? "hearts";
+  let bestCount = -1;
+  for (const suite of cardSuites) {
+    const count = counts.get(suite) ?? 0;
+    if (count > bestCount) {
+      bestSuit = suite;
+      bestCount = count;
+    }
+  }
+  return bestSuit;
+}
+
+function selectBotCard(hand: ICard[]): ICard | null {
+  if (!hand || hand.length === 0) {
+    return null;
+  }
+
+  const valueRanks = new Map(cardValues.map((value, index) => [value, index]));
+  const sorted = [...hand].sort((a, b) => {
+    const diff = a.valueNum - b.valueNum;
+    if (diff !== 0) {
+      return diff;
+    }
+    return (valueRanks.get(a.value) ?? 0) - (valueRanks.get(b.value) ?? 0);
+  });
+
+  return sorted[0] ?? null;
+}

--- a/packages/api/src/lib/listener/joinLeave.ts
+++ b/packages/api/src/lib/listener/joinLeave.ts
@@ -1,7 +1,9 @@
 import controller from "../game";
-import type { IPlayer } from "@coinche-reborn/api";
+import logger from "../logger";
+import type { IPlayer, PlayerPosition } from "@coinche-reborn/api";
 import addPlayer from "../actions/addPlayer";
-import removePlayer from "../actions/removePlayer";
+import { createBotPlayer, getBotId, isBotId, replacePlayerIdInState } from "../bot";
+import { maybeScheduleBotTurn } from "../botScheduler";
 
 /**
  * Handles player join/leave events for a game room.
@@ -14,14 +16,60 @@ export async function handlePlayerJoinLeave(event: any) {
   const gameController = controller.getInstance(gameId);
   const playersSetOld = gameController.getPlayers();
   if (event.type === "join") {
-    const player: IPlayer = {
-      id: playerId,
-      position: playersSetOld.length as any,
-      hands: [],
-      classement: 0,
-    };
-    addPlayer(player, gameId);
+    if (playersSetOld.some((player) => player.id === playerId)) {
+      return;
+    }
+
+    const botIndex = playersSetOld.findIndex((player) => isBotId(player.id));
+    if (botIndex >= 0) {
+      const botId = playersSetOld[botIndex]?.id;
+      if (botId) {
+        replacePlayerIdInState(gameController.state, botId, playerId);
+        gameController.sendState();
+      }
+    } else if (playersSetOld.length < 4) {
+      const player: IPlayer = {
+        id: playerId,
+        position: playersSetOld.length as PlayerPosition,
+        hands: [],
+        classement: 0,
+      };
+      addPlayer(player, gameId);
+    } else {
+      logger.warn(`[join] Game ${gameId} is full, ignoring player ${playerId}`);
+      return;
+    }
+
+    fillWithBots(gameId);
   } else if (event.type === "leave") {
-    removePlayer(playerId, gameId);
+    if (isBotId(playerId)) {
+      return;
+    }
+
+    const leavingPlayer = playersSetOld.find((player) => player.id === playerId);
+    if (!leavingPlayer) {
+      return;
+    }
+
+    const position =
+      typeof leavingPlayer.position === "number"
+        ? (leavingPlayer.position as PlayerPosition)
+        : ((playersSetOld.indexOf(leavingPlayer) || 0) as PlayerPosition);
+    const botId = getBotId(gameId, position);
+    replacePlayerIdInState(gameController.state, playerId, botId);
+    gameController.sendState();
+    maybeScheduleBotTurn(gameId);
+    fillWithBots(gameId);
+  }
+}
+
+function fillWithBots(gameId: string) {
+  const gameController = controller.getInstance(gameId);
+  if (gameController.state.status === "finished") {
+    return;
+  }
+  while (gameController.state.players.length < 4) {
+    const position = gameController.state.players.length as PlayerPosition;
+    addPlayer(createBotPlayer(gameId, position), gameId);
   }
 }


### PR DESCRIPTION
Add bot players to automatically fill empty game slots, manage their turns, and prevent database errors in bot-involved games.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-ed9eac72-1478-4501-900e-9b556ebb83cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ed9eac72-1478-4501-900e-9b556ebb83cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

